### PR TITLE
feat: add theme for vivid the LS_COLORS generator

### DIFF
--- a/extras/vivid/bamboo.yml
+++ b/extras/vivid/bamboo.yml
@@ -1,0 +1,123 @@
+colors:
+  # Theme colors
+  background_color: "1c1e1b"
+  purple: "aaaaff"
+  khaki: "e2c792"
+  pink: "e75a7c"
+  cyan: "70c2be"
+  green: "8fb573"
+  orange: "dbb671"
+
+  # Others
+  white: "fff8f0"
+  black: "1c1e1b"
+  red: "e75a7c"
+  gray: "b6b6b6"
+  dimgray: "5B5E5A"
+  gold: "dbb671"
+  springgreen: "8fb573"
+  darkgray: "3a3d37"
+
+core:
+  normal_text: {}
+  regular_file: {}
+  reset_to_normal: {}
+
+  directory:
+    foreground: cyan
+
+  symlink:
+    foreground: pink
+
+  multi_hard_link: {}
+
+  fifo:
+    foreground: black
+    background: cyan
+
+  socket:
+    foreground: black
+    background: pink
+
+  door:
+    foreground: black
+    background: pink
+
+  block_device:
+    foreground: cyan
+    background: darkgray
+
+  character_device:
+    foreground: pink
+    background: darkgray
+
+  broken_symlink:
+    foreground: black
+    background: red
+
+  missing_symlink_target:
+    foreground: black
+    background: red
+
+  setuid: {}
+
+  setgid: {}
+
+  file_with_capability: {}
+
+  sticky_other_writable: {}
+
+  other_writable: {}
+
+  sticky: {}
+
+  executable_file:
+    foreground: pink
+    font-style: bold
+
+text:
+  special:
+    foreground: black
+    background: khaki
+
+  todo:
+    font-style: bold
+
+  licenses:
+    foreground: gray
+
+  configuration:
+    foreground: green
+
+  other:
+    foreground: gold
+
+markup:
+  foreground: gold
+
+programming:
+  source:
+    foreground: springgreen
+
+  tooling:
+    foreground: green
+
+    continuous-integration:
+      foreground: khaki
+
+media:
+  foreground: orange
+
+office:
+  foreground: khaki
+
+archives:
+  foreground: pink
+  font-style: underline
+
+executable:
+  foreground: pink
+  font-style: bold
+
+unimportant:
+  foreground: dimgray


### PR DESCRIPTION
Hey, 
I just thought some custom LS_COLORS would go great with your theme and remembered that [vivid](https://github.com/sharkdp/vivid) exists. 

I took their molokai theme and replaced the colors with the ones from your theme that I felt fit best. If you're into it, I'd thought you might want to customize it to your liking and add it to your extras. 
