### PR TITLE
Customize float border to be more consistent with config parameters

### DIFF
--- a/lua/bamboo/highlights.lua
+++ b/lua/bamboo/highlights.lua
@@ -67,8 +67,12 @@ hl.common = {
   NormalNC = cfg.dim_inactive
       and { fg = c.light_grey, bg = util.darken(c.bg0, 0.875) }
     or { link = 'Normal' },
-  NormalFloat = { fg = c.fg, bg = cfg.transparent and c.none or c.bg0 },
-  FloatBorder = { fg = c.purple, bg = cfg.transparent and c.none or c.bg0 },
+  NormalFloat = cfg.dim_inactive
+      and { fg = c.fg, bg = util.darken(c.bg0, 0.875) }
+    or { link = 'Normal' },
+  FloatBorder = cfg.dim_inactive
+      and { fg = c.purple, bg = util.darken(c.bg0, 0.875) }
+    or { link = 'Normal' },
   FloatTitle = colors.Red,
   FloatFooter = colors.LightGrey,
   Terminal = { fg = c.fg, bg = cfg.transparent and c.none or c.bg0 },

--- a/lua/bamboo/highlights.lua
+++ b/lua/bamboo/highlights.lua
@@ -62,17 +62,13 @@ local colors = {
   Purple = { fg = c.purple },
 }
 
+local normal_bg = cfg.transparent and c.none or c.bg0
+local dimmable_bg = cfg.dim_inactive and util.darken(c.bg0, 0.875) or normal_bg
 hl.common = {
-  Normal = { fg = c.fg, bg = cfg.transparent and c.none or c.bg0 },
-  NormalNC = cfg.dim_inactive
-      and { fg = c.light_grey, bg = util.darken(c.bg0, 0.875) }
-    or { link = 'Normal' },
-  NormalFloat = cfg.dim_inactive
-      and { fg = c.fg, bg = util.darken(c.bg0, 0.875) }
-    or { link = 'Normal' },
-  FloatBorder = cfg.dim_inactive
-      and { fg = c.purple, bg = util.darken(c.bg0, 0.875) }
-    or { link = 'Normal' },
+  Normal = { fg = c.fg, bg = normal_bg },
+  NormalNC = { fg = c.light_grey, bg = dimmable_bg },
+  NormalFloat = { fg = c.fg, bg = dimmable_bg },
+  FloatBorder = { fg = c.purple, bg = dimmable_bg },
   FloatTitle = colors.Red,
   FloatFooter = colors.LightGrey,
   Terminal = { fg = c.fg, bg = cfg.transparent and c.none or c.bg0 },


### PR DESCRIPTION
Summary
-----
I find the changes here to be marginally more visually consistent (especially with plugins like fzf-lua and lspconfig which show floating windows for docs, search etc) if the user has specified `dim_inactive` and/or `transparent` config settings.

Merging this is really upto you @ribru17, please feel free to edit as necessary. If you dislike it I'm happy to continue using my fork. I just thought I'd make the PR regardless.