### PR TITLE
feat: add themes for Kitty

### DIFF
--- a/extras/kitty/bamboo.conf
+++ b/extras/kitty/bamboo.conf
@@ -1,0 +1,36 @@
+background              #252623
+foreground              #f1e9d2
+selection_background    #5b5e5a
+selection_foreground    #f1e9d2
+
+cursor              #fff8f0
+cursor_text_color   #0f0800
+
+active_tab_background       #f1e9d2
+active_tab_foreground       #111210
+inactive_tab_background     #3a3d37
+inactive_tab_foreground     #5b5e5a
+
+color0  #1c1e1b
+color8  #5b5e5a
+
+color1  #e75a7c
+color9  #e75a7c
+
+color2  #8fb573
+color10 #8fb573
+
+color3  #dbb671
+color11 #dbb671
+
+color4  #57a5e5
+color12 #57a5e5
+
+color5  #aaaaff
+color13 #aaaaff
+
+color6  #70c2be
+color14 #70c2be
+
+color7  #f1e9dc
+color15 #fff8f0

--- a/extras/kitty/bamboo_light.conf
+++ b/extras/kitty/bamboo_light.conf
@@ -1,0 +1,36 @@
+background              #fafae0
+foreground              #3a4238
+selection_background    #a1a7a0
+selection_foreground    #3a4238
+
+cursor              #0f0800
+cursor_text_color   #fff8f0
+
+active_tab_background       #3a4238
+active_tab_foreground       #fafae0
+inactive_tab_background     #c7c7af
+inactive_tab_foreground     #5b5e5a
+
+color0  #dadac2
+color8  #c7c7af
+
+color1  #c72a3c
+color9  #c72a3c
+
+color2  #4fa533
+color10 #4fa533
+
+color3  #bb9651
+color11 #bb9651
+
+color4  #1765d5
+color12 #1765d5
+
+color5  #8a4adf
+color13 #8a4adf
+
+color6  #00a2be
+color14 #00a2be
+
+color7  #3a4238
+color15 #252623

--- a/extras/kitty/bamboo_multiplex.conf
+++ b/extras/kitty/bamboo_multiplex.conf
@@ -1,0 +1,36 @@
+background              #232923
+foreground              #ece1c0
+selection_background    #5a5e5a
+selection_foreground    #ece1c0
+
+cursor              #fff8f0
+cursor_text_color   #0f0800
+
+active_tab_background       #ece1c0
+active_tab_foreground       #101210
+inactive_tab_background     #383d37
+inactive_tab_foreground     #5a5e5a
+
+color0  #171f17
+color8  #5a5e5a
+
+color1  #dc4f62
+color9  #dc4f62
+
+color2  #81af58
+color10 #81af58
+
+color3  #cebe69
+color11 #cebe69
+
+color4  #5692c4
+color12 #5692c4
+
+color5  #ae93e0
+color13 #ae93e0
+
+color6  #71ada2
+color14 #71ada2
+
+color7  #ece1c0
+color15 #fff8f0


### PR DESCRIPTION
Hello!

I really like this colorscheme and I thought that it would be nice to have this available on [Kitty](https://sw.kovidgoyal.net/kitty/). Thus, I created all three versions of the Bamboo colorscheme for it. Let me know what you think and/or if I need to make any changes.

Here are some images for reference:

### Bamboo:

![bamboo-kitty](https://github.com/ribru17/bamboo.nvim/assets/21070577/1ef1e2e0-d817-4933-8f7b-248227996cb4)

### Bamboo Multiplex:

![bamboo-multiplex-kitty](https://github.com/ribru17/bamboo.nvim/assets/21070577/88908727-04d6-483c-9e65-6ebd0c42719f)

### Bamboo Light:

![bamboo-light-kitty](https://github.com/ribru17/bamboo.nvim/assets/21070577/b78f8a9c-9513-4185-9373-907b998af8f6)