### PR TITLE
feat: create colorscheme files for all themes

### DIFF
--- a/colors/bamboo-light.lua
+++ b/colors/bamboo-light.lua
@@ -1,0 +1,9 @@
+for k in pairs(package.loaded) do
+  if k:match('.*bamboo.*') then
+    package.loaded[k] = nil
+  end
+end
+
+vim.opt.background = 'light'
+require('bamboo').setup { style = 'light' }
+require('bamboo').colorscheme()

--- a/colors/bamboo-light.lua
+++ b/colors/bamboo-light.lua
@@ -4,6 +4,6 @@ for k in pairs(package.loaded) do
   end
 end
 
-vim.opt.background = 'light'
-require('bamboo').setup { style = 'light' }
+require('bamboo').set_options('style', 'light')
+vim.o.background = 'light'
 require('bamboo').colorscheme()

--- a/colors/bamboo-multiplex.lua
+++ b/colors/bamboo-multiplex.lua
@@ -4,6 +4,6 @@ for k in pairs(package.loaded) do
   end
 end
 
-vim.opt.background = 'dark'
-require('bamboo').setup { style = 'multiplex' }
+require('bamboo').set_options('style', 'multiplex')
+vim.o.background = 'dark'
 require('bamboo').colorscheme()

--- a/colors/bamboo-multiplex.lua
+++ b/colors/bamboo-multiplex.lua
@@ -1,0 +1,9 @@
+for k in pairs(package.loaded) do
+  if k:match('.*bamboo.*') then
+    package.loaded[k] = nil
+  end
+end
+
+vim.opt.background = 'dark'
+require('bamboo').setup { style = 'multiplex' }
+require('bamboo').colorscheme()

--- a/colors/bamboo-vulgaris.lua
+++ b/colors/bamboo-vulgaris.lua
@@ -1,0 +1,9 @@
+for k in pairs(package.loaded) do
+  if k:match('.*bamboo.*') then
+    package.loaded[k] = nil
+  end
+end
+
+vim.opt.background = 'dark'
+require('bamboo').setup { style = 'vulgaris' }
+require('bamboo').colorscheme()

--- a/colors/bamboo-vulgaris.lua
+++ b/colors/bamboo-vulgaris.lua
@@ -4,6 +4,6 @@ for k in pairs(package.loaded) do
   end
 end
 
-vim.opt.background = 'dark'
-require('bamboo').setup { style = 'vulgaris' }
+require('bamboo').set_options('style', 'vulgaris')
+vim.o.background = 'dark'
 require('bamboo').colorscheme()


### PR DESCRIPTION
I tried to keep the diff minimal, so I only added the three files. Some points that are now suboptimal are

- Repeated code for clearing the cached `bamboo` module. This could be a util function? I didn't see why clearing the cache was necessary, so I kept it as-is.
- Loading a colorscheme with `:colorscheme bamboo-multiplex` will now override the default `style` option in the config. This could be changed by passing in a config to the methods that actually set highlight groups instead of using a global, but again, I didn't want to change to  much xD
- I manually have to set the dark/light background.

closes: #15