### PR TITLE
fix(blink.cmp): menu highlight

### DIFF
--- a/lua/bamboo/highlights.lua
+++ b/lua/bamboo/highlights.lua
@@ -558,7 +558,7 @@ hl.plugins.blinkcmp = {
   BlinkCmpKindCopilot = { fg = c.fg, reverse = cfg.cmp_itemkind_reverse },
   BlinkCmpKindCodeium = { fg = c.fg, reverse = cfg.cmp_itemkind_reverse },
   BlinkCmpKindTabNine = { fg = c.fg, reverse = cfg.cmp_itemkind_reverse },
-  BlinkCmpMenu = { link = 'FloatNormal' },
+  BlinkCmpMenu = { link = 'NormalFloat' },
   BlinkCmpMenuBorder = { link = 'FloatBorder' },
   BlinkCmpDocBorder = { link = 'FloatBorder' },
 }


### PR DESCRIPTION
I think `FloatNormal` should be `NormalFloat`.