### PR TITLE
feat: support blink.delimiters highlights

### DIFF
--- a/lua/bamboo/highlights.lua
+++ b/lua/bamboo/highlights.lua
@@ -544,6 +544,16 @@ hl.plugins.barbar = {
   BufferVisibleTarget = { fg = c.light_grey, bg = c.bg0 },
 }
 
+hl.plugins.blink_delimiters = {
+  RainbowRed = { fg = rainbows.red },
+  RainbowOrange = { fg = rainbows.orange },
+  RainbowYellow = { fg = rainbows.yellow },
+  RainbowGreen = { fg = rainbows.green },
+  RainbowCyan = { fg = rainbows.cyan },
+  RainbowBlue = { fg = rainbows.blue },
+  RainbowPurple = { fg = rainbows.purple },
+}
+
 hl.plugins.blinkcmp = {
   BlinkCmpGhostText = {
     fg = c.light_grey,


### PR DESCRIPTION
Adds highlights for [blink.delimiters](https://github.com/Saghen/blink.nvim/tree/main/readmes/delimiters)