### PR TITLE
add reference to zed theme port

### DIFF
--- a/extras/zed/README.md
+++ b/extras/zed/README.md
@@ -1,0 +1,3 @@
+# Bamboo for Zed
+
+This page links to a [port](https://github.com/LoamStudios/zed-bamboo-theme) of the theme for [Zed](https://zed.dev).


### PR DESCRIPTION
In this PR, I add a README to link out to the Zed port of the theme.

The port is an early first version. It will need some tweaking, but at least now we have comfy eyes.