### PR TITLE
extras: vulgaris and multiplex fzf colors

### DIFF
--- a/extras/fzf/README.md
+++ b/extras/fzf/README.md
@@ -1,5 +1,31 @@
 # Bamboo Colors for FZF
 
+## Bamboo Vulgaris
+
+Append colors to `FZF_DEFAULT_OPTS`:
+
+```sh
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS \
+  --color=bg+:#2f312c,bg:#252623,spinner:#e75a7c,hl:#e75a7c \
+  --color=fg:#f1e9d2,header:#e75a7c,info:#96c7ef,pointer:#8fb573 \
+  --color=marker:#8fb573,fg+:#8fb573,prompt:#8fb573,hl+:#e75a7c \
+  --color=selected-bg:#383b35 \
+  "
+```
+
+## Bamboo Multiplex
+
+Append colors to `FZF_DEFAULT_OPTS`:
+
+```sh
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS \
+  --color=bg+:#2d312c,bg:#232923,spinner:#dc4f62,hl:#dc4f62 \
+  --color=fg:#ece1c0,header:#dc4f62,info:#88c1e9,pointer:#81af58 \
+  --color=marker:#81af58,fg+:#81af58,prompt:#81af58,hl+:#dc4f62 \
+  --color=selected-bg:#363b35 \
+  "
+```
+
 ## Bamboo Light
 
 Append colors to `FZF_DEFAULT_OPTS`:


### PR DESCRIPTION
Hi there,

I really like your theme but noticed that only one of the three color palettes has fzf support. So I created my own version of the darker colors and would like to contribute them back. They use the corresponding palette entries as the light version does (e.g. bg1 for bg+, red for spinner and so on...)

If that works for you I would also like to add the two missing lazygit themes.  🙂